### PR TITLE
add_awaのsesでメール送信できるように設定

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'test@cocktailsearch.ga'
   layout 'mailer'
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,12 +30,13 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local
 
+  # 開発環境
+  #config.action_mailer.default_url_options = { host: 'localhost'}
+  #config.action_mailer.smtp_settings = { :address => "smtp", :port => 1025 } 
   #メール機能について
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = { :address => "smtp", :port => 1025 }
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: 'localhost'}
-  config.action_mailer.perform_caching = false
+  config.action_mailer.perform_caching = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,7 +63,13 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "cocktailSearchApp_#{Rails.env}"
 
-  config.action_mailer.perform_caching = false
+  # 開発環境
+  #config.action_mailer.default_url_options = { host: 'localhost'}
+  #config.action_mailer.smtp_settings = { :address => "smtp", :port => 1025 } 
+  #メール機能について
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.perform_caching = true
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
目的
awsのsesを用いてアカウント有効のメールを送信できるようにする