### PR TITLE
fix_nginxの画像キャッシュ設定と空白削除

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-# dockerfile 
+# dockerfile
 # 開発rubyバージョン指定
 FROM ruby:2.5.1
 
 # 必要なパッケージのインストール
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get update -qq && \
-    apt-get install -y build-essential \ 
-                       libpq-dev \        
-                       nodejs           
+    apt-get install -y build-essential \
+                       libpq-dev \
+                       nodejs
 
 # 作業ディレクトリの作成、設定
 RUN mkdir /cocktailSearchApp
@@ -21,11 +21,11 @@ ADD ./Gemfile $APP_ROOT/Gemfile
 ADD ./Gemfile.lock $APP_ROOT/Gemfile.lock
 
 # Gemfileのbundle install
-RUN bundle install 
+RUN bundle install
 ADD . $APP_ROOT
 
 # puma.sockを配置するディレクトリを作成
 RUN mkdir -p tmp/sockets
 
 RUN mkdir -p /tmp/public && \
-    cp -rf /cocktailSearchApp/public/* /tmp/public 
+    cp -rf /cocktailSearchApp/public/* /tmp/public

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,5 +7,5 @@ plugin :tmp_restart
 # ここから下を追記--------------------------------------------
 app_root = File.expand_path("../..", __FILE__)
 bind "unix://#{app_root}/tmp/sockets/puma.sock"
- 
+
 stdout_redirect "#{app_root}/log/puma.stdout.log", "#{app_root}/log/puma.stderr.log", true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,11 +31,11 @@ services:
     ports:
       - "3000:3000"
     links:
-      - db 
+      - db
 
   nginx:
     # docker-compose buildのときにビルドするためのDockerfileのパス
-    build: 
+    build:
       context: ./nginx
     ports:
       - 80:80

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -16,7 +16,7 @@ server {
   root /cocktailSearchApp/public;
 
   large_client_header_buffers 4 32k;
-  
+
   client_max_body_size 100m;
   error_page 404             /404.html;
   error_page 505 502 503 504 /500.html;
@@ -28,6 +28,9 @@ server {
     proxy_ignore_client_abort on;
     proxy_read_timeout 300;
     proxy_connect_timeout 300;
+    proxy_buffer_size 32k;
+    proxy_buffers 50 32k;
+    proxy_busy_buffers_size 32k;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $http_host;


### PR DESCRIPTION
目的
サーバダウンのエラーの一つに画像のキャッシュ保存が超えたためとあったので、対応した